### PR TITLE
Update save syntax

### DIFF
--- a/.github/workflows/python-package-build-test.yml
+++ b/.github/workflows/python-package-build-test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ requirements = readfile("requirements.txt")
 
 setup(
     name='trc-data-reader',
-    version='0.3.4',
+    version='0.3.5',
     py_modules=['trc'],
     package_dir={'': 'src'},
     url='https://github.com/hsorby/trc-data-reader',

--- a/src/trc.py
+++ b/src/trc.py
@@ -232,7 +232,7 @@ class TRCData(dict):
             # Set marker labels.
             self['Markers'] = [label for label in point_labels if label]
             self['NumMarkers'] = len(self['Markers'])
-    
+
             # Set marker data.
             for i, points, analog in reader.read_frames():
                 time = (i - 1) * (1 / reader.point_rate)
@@ -279,8 +279,8 @@ class TRCData(dict):
         coordinate_labels = _COORDINATE_LABELS[:data_format_count]
         markers_header = [entry for marker in self['Markers'] for entry in [marker, '', '']]
         marker_sub_heading = [f'{coordinate}{i + 1}' for i in range(len(self['Markers'])) for coordinate in coordinate_labels]
-        data_header_line_1 = 'Frame#\tTime\t' + '\t'.join(markers_header) + os.linesep
-        data_header_line_2 = '\t\t' + '\t'.join(marker_sub_heading) + os.linesep
+        data_header_line_1 = 'Frame#\tTime\t' + '\t'.join(markers_header) + '\t' + os.linesep
+        data_header_line_2 = '\t\t' + '\t'.join(marker_sub_heading) + '\t' + os.linesep
 
         blank_line = os.linesep
 
@@ -299,7 +299,7 @@ class TRCData(dict):
                 time, line_data = self[frame]
                 values = ['' if math.isnan(v) else f'{v:.5f}' for values in line_data for v in values]
                 numeric_values = '\t'.join(values)
-                f.write(f'{frame}\t{time:.3f}\t{numeric_values}{os.linesep}')
+                f.write(f'{frame}\t{time:.3f}\t{numeric_values}\t{os.linesep}')
 
 
 # #!/usr/bin/env python

--- a/tests/test_trc.py
+++ b/tests/test_trc.py
@@ -202,9 +202,25 @@ class TestStoreTRC(unittest.TestCase):
         with open(output_file, 'r') as file:
             lines = file.readlines()
         for line in lines[6:]:
-            values = line.strip('\n').strip('\r').split('\t')[:-1]
+            values = line.strip('\n').strip('\r').split('\t')
             self.assertEqual(26, len(values))
             self.assertEqual(12, values.count(''))
+
+        os.remove(output_file)
+
+    def test_save_file_06(self):
+        output_file = os.path.join(resource_path, 'c3d_test_file_03_out.trc')
+        data = TRCData()
+        data.import_from(os.path.join(resource_path, 'c3d_test_file_03.c3d'))
+        data.save(output_file, add_trailing_tab=True)
+
+        # Check that the missing coordinates were written as empty strings.
+        with open(output_file, 'r') as file:
+            lines = file.readlines()
+        for line in lines[6:]:
+            values = line.strip('\n').strip('\r').split('\t')
+            self.assertEqual(27, len(values))
+            self.assertEqual(13, values.count(''))
 
         os.remove(output_file)
 

--- a/tests/test_trc.py
+++ b/tests/test_trc.py
@@ -202,7 +202,7 @@ class TestStoreTRC(unittest.TestCase):
         with open(output_file, 'r') as file:
             lines = file.readlines()
         for line in lines[6:]:
-            values = line.strip('\n').strip('\r').split('\t')
+            values = line.strip('\n').strip('\r').split('\t')[:-1]
             self.assertEqual(26, len(values))
             self.assertEqual(12, values.count(''))
 


### PR DESCRIPTION
This PR makes some minor adjustments to the `save` method.

Current OpenSim releases expect an additional tab at the end of the data and data-header lines, and will fail to load the TRC file (due to `RuntimeError: Unexpected number of columns`) if there are missing coordinate values at the end of a line. Adding these additional tabs fixes the issue.

The `_process_contents` method still works on files using this new format as it strips the contents of each line before processing.

The new file format is still supported by Mokka in addition to OpenSim.

Test case `test_save_file_05` has been updated to match the updated file format. All other tests are working as they were previously.