### PR TITLE
Improve compatibility for older C3D files

### DIFF
--- a/src/trc.py
+++ b/src/trc.py
@@ -224,7 +224,7 @@ class TRCData(dict):
             self['DataRate'] = reader.header.frame_rate
             self['CameraRate'] = reader.header.frame_rate
             self['NumFrames'] = reader.header.last_frame - reader.header.first_frame + 1
-            self['Units'] = reader.get('POINT').get('UNITS').string_value
+            self['Units'] = reader.get('POINT').get('UNITS').string_value.rstrip('\x00')
             self['OrigDataRate'] = reader.header.frame_rate
             self['OrigDataStartFrame'] = reader.header.first_frame
             self['OrigNumFrames'] = reader.header.last_frame - reader.header.first_frame + 1


### PR DESCRIPTION
Some older C3D software writes fixed-length strings padded with null bytes for the 'POINT:UNITS' parameter. The null bytes will propagate into the TRC data/file and will cause OpenSim compatibility issues further down the line.